### PR TITLE
Update channel when no fastq merge

### DIFF
--- a/split-pipe/main.nf
+++ b/split-pipe/main.nf
@@ -91,6 +91,7 @@ workflow pb_splitpipe {
        splitpipe_all(merge_fastqs.out.sublibrary_read_pairs)
  
        } else {
+       samples_sublibraries = Channel.fromFilePairs( sub_libraries, flat: true )
        splitpipe_all(samples_sublibraries)
        }
        if ( params.combine ) {


### PR DESCRIPTION
When no fastq merging is specified, the sub-library input can specify a glob pattern to find all fastq pairs, each treated as a sub-library. 
Future documentation will need to specify what possible inputs are allowed for params.sublibrary. 